### PR TITLE
✨ feat: 짜증 회고록 상세 조회(댓글 조회까지 포함), 짜증 회고록 댓글 생성 기능 개발(#34)

### DIFF
--- a/src/main/java/org/oa/mindbook/Controller/MemoirComment/AnnoyMemoirCommentController.java
+++ b/src/main/java/org/oa/mindbook/Controller/MemoirComment/AnnoyMemoirCommentController.java
@@ -1,0 +1,28 @@
+package org.oa.mindbook.Controller.MemoirComment;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.oa.mindbook.Dto.request.MemoirComment.CreateAnnoyMemoirCommentRequestDto;
+import org.oa.mindbook.Service.MemoirComment.AnnoyMemoirCommentService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/annoyMemoirComment")
+public class AnnoyMemoirCommentController {
+
+    private final AnnoyMemoirCommentService annoyMemoirCommentService;
+
+    @PostMapping("")
+    public String createAnnoyMemoirComment(@RequestBody CreateAnnoyMemoirCommentRequestDto dto) {
+
+        annoyMemoirCommentService.saveAnnoyMemoirComment(dto);
+
+        return "짜증 회고록 댓글이 작성되었습니다.";
+
+    }
+}

--- a/src/main/java/org/oa/mindbook/Domain/Entity/MemoirComment/AnnoyMemoirComment.java
+++ b/src/main/java/org/oa/mindbook/Domain/Entity/MemoirComment/AnnoyMemoirComment.java
@@ -1,0 +1,31 @@
+package org.oa.mindbook.Domain.Entity.MemoirComment;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.oa.mindbook.Domain.BaseTimeEntity;
+import org.oa.mindbook.Domain.Entity.Memoir.AnnoyMemoir;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "AnnoyMemoirComment")
+public class AnnoyMemoirComment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long annoyMemoirCommentId;
+
+    private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "annoyMemoirId", nullable = false)
+    private AnnoyMemoir annoyMemoir;
+
+    private String content;
+
+}

--- a/src/main/java/org/oa/mindbook/Dto/request/MemoirComment/CreateAnnoyMemoirCommentRequestDto.java
+++ b/src/main/java/org/oa/mindbook/Dto/request/MemoirComment/CreateAnnoyMemoirCommentRequestDto.java
@@ -1,0 +1,17 @@
+package org.oa.mindbook.Dto.request.MemoirComment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateAnnoyMemoirCommentRequestDto {
+
+    private Long userId;
+
+    private Long annoyMemoirId;
+
+    private String content;
+}

--- a/src/main/java/org/oa/mindbook/Dto/response/Memoir/AnnoyMemoirResponseDto.java
+++ b/src/main/java/org/oa/mindbook/Dto/response/Memoir/AnnoyMemoirResponseDto.java
@@ -5,6 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.oa.mindbook.Domain.Entity.Memoir.AnnoyMemoir;
+import org.oa.mindbook.Dto.response.MemoirComment.AnnoyMemoirCommentResponseDto;
+
+import java.util.Collection;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -24,7 +28,9 @@ public class AnnoyMemoirResponseDto {
 
     private String status;
 
-    public static AnnoyMemoirResponseDto of(AnnoyMemoir annoyMemoir) {
+    private List<AnnoyMemoirCommentResponseDto> commentList;
+
+    public static AnnoyMemoirResponseDto of(AnnoyMemoir annoyMemoir, List<AnnoyMemoirCommentResponseDto> commentList) {
         return AnnoyMemoirResponseDto.builder()
                 .annoyMemoirId(annoyMemoir.getAnnoyMemoirId())
                 .userId(annoyMemoir.getUserId())
@@ -32,6 +38,7 @@ public class AnnoyMemoirResponseDto {
                 .memory(annoyMemoir.getMemory())
                 .impression(annoyMemoir.getImpression())
                 .status(annoyMemoir.getStatus())
+                .commentList(commentList)
                 .build();
     }
 }

--- a/src/main/java/org/oa/mindbook/Dto/response/MemoirComment/AnnoyMemoirCommentResponseDto.java
+++ b/src/main/java/org/oa/mindbook/Dto/response/MemoirComment/AnnoyMemoirCommentResponseDto.java
@@ -1,0 +1,21 @@
+package org.oa.mindbook.Dto.response.MemoirComment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnnoyMemoirCommentResponseDto {
+
+    private Long annoyMemoirCommentId;
+
+    private String nickname;
+
+    private String content;
+
+    private String createdAt;
+}

--- a/src/main/java/org/oa/mindbook/Repository/MemoirComment/AnnoyMemoirCommentRepository.java
+++ b/src/main/java/org/oa/mindbook/Repository/MemoirComment/AnnoyMemoirCommentRepository.java
@@ -1,0 +1,13 @@
+package org.oa.mindbook.Repository.MemoirComment;
+
+import org.oa.mindbook.Domain.Entity.MemoirComment.AnnoyMemoirComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface AnnoyMemoirCommentRepository extends JpaRepository<AnnoyMemoirComment, Long> {
+
+    @Query(value = "select c from AnnoyMemoirComment c where c.annoyMemoir.annoyMemoirId = :id")
+    List<AnnoyMemoirComment> findByAnnoyMemoirId(Long id);
+}

--- a/src/main/java/org/oa/mindbook/Service/Memoir/AnnoyMemoirService.java
+++ b/src/main/java/org/oa/mindbook/Service/Memoir/AnnoyMemoirService.java
@@ -6,8 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.oa.mindbook.Domain.Entity.Memoir.AnnoyMemoir;
 import org.oa.mindbook.Dto.request.Memoir.CreateAnnoyMemoirRequestDto;
 import org.oa.mindbook.Dto.response.Memoir.AnnoyMemoirResponseDto;
+import org.oa.mindbook.Dto.response.MemoirComment.AnnoyMemoirCommentResponseDto;
 import org.oa.mindbook.Repository.Memoir.AnnoyMemoirRepository;
+import org.oa.mindbook.Repository.MemoirComment.AnnoyMemoirCommentRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -15,19 +20,31 @@ import org.springframework.stereotype.Service;
 public class AnnoyMemoirService {
 
     private final AnnoyMemoirRepository annoyMemoirRepository;
+    private final AnnoyMemoirCommentRepository annoyMemoirCommentRepository;
 
     @Transactional
-    public AnnoyMemoirResponseDto saveAnnoyMemoir(CreateAnnoyMemoirRequestDto createAnnoyMemoirRequestDto) {
+    public void saveAnnoyMemoir(CreateAnnoyMemoirRequestDto createAnnoyMemoirRequestDto) {
 
         AnnoyMemoir annoyMemoir = annoyMemoirRepository.save(createAnnoyMemoirRequestDto.toEntity());
 
-        return AnnoyMemoirResponseDto.of(annoyMemoir);
     }
 
     @Transactional
     public AnnoyMemoirResponseDto getAnnoyMemoir(Long annoyMemoirId) {
         AnnoyMemoir annoyMemoir = annoyMemoirRepository.findById(annoyMemoirId).orElseThrow();
+        List<AnnoyMemoirCommentResponseDto> commentList = annoyMemoirCommentRepository.findByAnnoyMemoirId(annoyMemoirId).stream().map(
+                comment -> {
+                    return AnnoyMemoirCommentResponseDto.builder()
+                            .annoyMemoirCommentId(comment.getAnnoyMemoirCommentId())
+//                            .nickname(comment.getUser().getUserId())
+                            .nickname("nickname")
+                            .content(comment.getContent())
+                            .createdAt(comment.getCreatedAt())
+                            .build();
 
-        return AnnoyMemoirResponseDto.of(annoyMemoir);
+                }
+        ).collect(Collectors.toList());
+
+        return AnnoyMemoirResponseDto.of(annoyMemoir, commentList);
     }
 }

--- a/src/main/java/org/oa/mindbook/Service/MemoirComment/AnnoyMemoirCommentService.java
+++ b/src/main/java/org/oa/mindbook/Service/MemoirComment/AnnoyMemoirCommentService.java
@@ -1,0 +1,32 @@
+package org.oa.mindbook.Service.MemoirComment;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.oa.mindbook.Domain.Entity.Memoir.AnnoyMemoir;
+import org.oa.mindbook.Domain.Entity.MemoirComment.AnnoyMemoirComment;
+import org.oa.mindbook.Dto.request.MemoirComment.CreateAnnoyMemoirCommentRequestDto;
+import org.oa.mindbook.Repository.Memoir.AnnoyMemoirRepository;
+import org.oa.mindbook.Repository.MemoirComment.AnnoyMemoirCommentRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AnnoyMemoirCommentService {
+
+    private final AnnoyMemoirRepository annoyMemoirRepository;
+    private final AnnoyMemoirCommentRepository annoyMemoirCommentRepository;
+
+    @Transactional
+    public void saveAnnoyMemoirComment(CreateAnnoyMemoirCommentRequestDto dto) {
+        AnnoyMemoir annoyMemoir = annoyMemoirRepository.findById(dto.getAnnoyMemoirId()).orElseThrow();
+
+        annoyMemoirCommentRepository.save(AnnoyMemoirComment.builder()
+                .userId(dto.getUserId())
+                .annoyMemoir(annoyMemoir)
+                .content(dto.getContent())
+                .build());
+
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #34 

# 🔎 Key Changes
- 짜증 회고록 댓글 생성
- RequestBody
![image](https://github.com/user-attachments/assets/97c73b8a-e1be-480a-8ce7-427ec8c7ae01)
- DB
![image](https://github.com/user-attachments/assets/7e71900a-1383-4819-bbe6-ab49149783cc)

- 짜증 회고록 상세 조회(댓글조회까지 포함)
- Path
![image](https://github.com/user-attachments/assets/217accaf-a87a-49d3-bde3-87d48e335696)
